### PR TITLE
Update for more verbose compiling to avoid timeouts in automated builds

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,9 +16,9 @@ then
 else
     # GNU/Linux recipe
     export JCC_ARGSEP=";"
-	export JCC_LFLAGS="-v;-L$PREFIX/jre/lib/amd64;-ljava;-L$PREFIX/jre/lib/amd64/server;-ljvm;-lverify;-Wl,-rpath=$PREFIX/jre/lib/amd64:$PREFIX/jre/lib/amd64/server"
+	export JCC_LFLAGS="-v;-Wl,-v;-L$PREFIX/jre/lib/amd64;-ljava;-L$PREFIX/jre/lib/amd64/server;-ljvm;-lverify;-Wl,-rpath=$PREFIX/jre/lib/amd64:$PREFIX/jre/lib/amd64/server"
 	export JCC_JAVAC=$PREFIX/bin/javac
-	export JCC_CFLAGS="-fno-strict-aliasing;-Wno-write-strings;-D__STDC_FORMAT_MACROS"
+	export JCC_CFLAGS="-v;-fno-strict-aliasing;-Wno-write-strings;-D__STDC_FORMAT_MACROS"
 
 	printenv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
 build:
   skip: true  # [win32 or linux32]
 
-  number: 0
+  number: 1
 
   rpaths: # only valid for linux
     - lib


### PR DESCRIPTION
The circleci automated builds has a timeout of 10 minutes of no printout. Increasing verbosity of JCC to reduce risk that it cancels the build.